### PR TITLE
Fix constant "Error Downloading ..." on some Android 5.x devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!--  is required for some Android 5.x devices  -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
 
     <queries>
         <package android:name="com.vanced.android.youtube" />


### PR DESCRIPTION
WRITE_EXTERNAL_STORAGE permission is still required for some Android 5.x firmwares.