### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -33,7 +33,7 @@
     <string name="unavailable">利用不可</string>
     <string name="update">更新</string>
     <string name="useful_links">リンク集</string>
-    <string name="support_us">Brave をダウンロードして支援する</string>
+    <string name="support_us">ダウンロードして支援する</string>
     <!-- Settings -->
     <string name="accent_color">アクセントカラー</string>
     <string name="accent_blue">青</string>


### PR DESCRIPTION
When see string "Brave" but Icon is Brave and AdGuard.
So When use both string, Should to use "Download and Support" in Japanese "ダウンロードして支援する" or "Download other app" in Japanese "他のアプリをダウンロードする"
not need "Braveを"