### PR TITLE
Set installer package to Play Store for root variant

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <package android:name="com.vanced.android.apps.youtube.music" />
         <package android:name="com.google.android.apps.youtube.music" />
         <package android:name="com.mgoogle.android.gms" />
+        <package android:name="com.android.vending" />
     </queries>
 
     <application

--- a/app/src/main/java/com/vanced/manager/utils/AppUtils.kt
+++ b/app/src/main/java/com/vanced/manager/utils/AppUtils.kt
@@ -22,6 +22,7 @@ object AppUtils: CoroutineScope by CoroutineScope(Dispatchers.IO) {
     const val musicRootPkg = "com.google.android.apps.youtube.music"
     const val microgPkg = "com.mgoogle.android.gms"
     const val managerPkg = APPLICATION_ID
+    const val playStorePkg = "com.android.vending"
 
     fun sendRefresh(context: Context): Job {
         return launch {


### PR DESCRIPTION
In some Android 11 installation, Play Services refuse to work if the calling package does not come from a legit source (e.g. Play Store). Be sloppy about version detection and whether the operation succeeded as this appears to happen only in Android 11.