### PR TITLE
Ignore Markdown Files While Pushing Or Pull Requesting

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - dev
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - dev
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
If you merge this to dev, you can stop workflow file (actions) from executing while editing markdown files