### PR TITLE
Splash screen background color (fix for #469)

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--Splash screen color for dark/night theme-->
+    <color name="splash">#131317</color>
+
+</resources>
+

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="Gray">#5F5E5E</color>
     <color name="White">#ffffff</color>
     <color name="Black">#000000</color>
-    <color name="splash">#131317</color>
+    <!--Splash screen color for light/day theme-->
+    <color name="splash">#cfcfcf</color>
 
 </resources>


### PR DESCRIPTION
Hi, this pr fixes splash screen background colors (issue #469). It would be nice to see dark and light splash themes... I'm not sure whether the colors I picked would look spectacularly amazing but anyway here is a quick fix.