### PR TITLE
Auto-dismiss radio dialog when selecting an option

### DIFF
--- a/app/src/main/java/com/vanced/manager/ui/dialogs/AppVersionSelectorDialog.kt
+++ b/app/src/main/java/com/vanced/manager/ui/dialogs/AppVersionSelectorDialog.kt
@@ -64,11 +64,13 @@ class AppVersionSelectorDialog :
                 tag.isChecked = true
             }
             dialogTitle.text = getString(R.string.version)
-            dialogSave.setOnClickListener {
+            dialogRadiogroup.setOnCheckedChangeListener { _, _ ->
                 val checkedTag = dialogRadiogroup.checkedButtonTag
+
                 if (checkedTag != null) {
                     prefs.edit { putString("${arguments?.getString(TAG_APP)}_version", checkedTag) }
                 }
+
                 dismiss()
             }
         }

--- a/app/src/main/java/com/vanced/manager/ui/dialogs/VancedThemeSelectorDialog.kt
+++ b/app/src/main/java/com/vanced/manager/ui/dialogs/VancedThemeSelectorDialog.kt
@@ -56,7 +56,7 @@ class VancedThemeSelectorDialog :
             if (tag != null) {
                 tag.isChecked = true
             }
-            dialogSave.setOnClickListener {
+            dialogRadiogroup.setOnCheckedChangeListener { _, _ ->
                 val checkedTag = binding.dialogRadiogroup.checkedButtonTag
                 if (checkedTag != null) {
                     prefs.theme = checkedTag

--- a/app/src/main/res/layout/dialog_bottom_radio_button.xml
+++ b/app/src/main/res/layout/dialog_bottom_radio_button.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/BottomDialogCard">
+                                                   xmlns:tools="http://schemas.android.com/tools" style="@style/BottomDialogCard">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -18,14 +18,8 @@
             <RadioGroup
                 android:id="@+id/dialog_radiogroup"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-            </RadioGroup>
+                android:layout_height="wrap_content"/>
         </androidx.core.widget.NestedScrollView>
 
-        <com.vanced.manager.ui.core.ThemedMaterialButton
-            android:id="@+id/dialog_save"
-            android:text="@string/save"
-            style="@style/BottomDialogButtonStyle" />
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
This fixes the the save button not showing up by... removing it. There is no real need for the button, selecting a radio item now automatically applies the setting.

Affected dialogs are the version selector and the theme selector for YouTubeVanced.

Closes #654 