### PR TITLE
Add background updates on Android 12

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/app/src/main/java/com/vanced/manager/utils/PackageHelper.kt
+++ b/app/src/main/java/com/vanced/manager/utils/PackageHelper.kt
@@ -282,6 +282,9 @@ object PackageHelper {
         val sessionId: Int
         val sessionParams =
             PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            sessionParams.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED)
+        }
         val callbackIntent = Intent(context, AppInstallerService::class.java)
         val pendingIntent = PendingIntent.getService(context, 0, callbackIntent, intentFlags)
         try {

--- a/app/src/main/java/com/vanced/manager/utils/PackageHelper.kt
+++ b/app/src/main/java/com/vanced/manager/utils/PackageHelper.kt
@@ -163,6 +163,9 @@ object PackageHelper {
         val packageInstaller = context.packageManager.packageInstaller
         val params =
             PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED)
+        }
         val sessionId: Int
         var session: PackageInstaller.Session? = null
         try {


### PR DESCRIPTION
A new feature on Android 12 lets Vanced Manager run a update without showing a system prompt first. This PR adds the necessary flags to do so, but doesn't change the existing notification workflow.

https://www.xda-developers.com/android-12-alternative-app-stores-update-apps-background/

If you like this, a hacktoberfest-accepted label would be appreciated 😄 